### PR TITLE
1763/criar rotas das redes sociais do usuario

### DIFF
--- a/src/modules/event-modules/event-participant/event/dto/event-participant-response.dto.ts
+++ b/src/modules/event-modules/event-participant/event/dto/event-participant-response.dto.ts
@@ -15,6 +15,7 @@ import {
   QuizCreateResponseSchema,
   FindTicketByLinkResponseSchema,
   UserIsParticipantInEventByLinkIdResponseSchema,
+  ParticipantSocialNetworSchema,
 } from '../schema/event-participant-response.schema';
 import { ApiProperty } from '@nestjs/swagger';
 import { PaginationResponse } from 'src/dtos/pagination.dto';
@@ -62,6 +63,17 @@ export class FindTicketByLinkResponseDto extends createZodDto(
 export class UserIsParticipantInEventByLinkIdResponseDto extends createZodDto(
   UserIsParticipantInEventByLinkIdResponseSchema,
 ) {}
+
+export class ParticipantSocialNetworDto extends createZodDto(
+  ParticipantSocialNetworSchema,
+) {}
+
+export class ParticipantSocialNetworks {
+  @ApiProperty({
+    type: () => [ParticipantSocialNetworDto],
+  })
+  data: ParticipantSocialNetworDto[];
+}
 
 export class FindAllPublicEvents {
   @ApiProperty({

--- a/src/modules/event-modules/event-participant/event/event-participant.controller.ts
+++ b/src/modules/event-modules/event-participant/event/event-participant.controller.ts
@@ -1,4 +1,5 @@
-import {  Body,
+import {
+  Body,
   Controller,
   Get,
   Param,
@@ -46,6 +47,7 @@ import {
   QuizCreateResponseDto,
   FindTicketByLinkResponseDto,
   UserIsParticipantInEventByLinkIdResponseDto,
+  ParticipantSocialNetworks,
 } from './dto/event-participant-response.dto';
 import { ClickSignApiService } from 'src/services/click-sign.service';
 import { AuthUserGuard } from 'src/modules/auth-modules/auth/auth-user.guards';
@@ -545,6 +547,24 @@ export class EventParticipantController {
     return await this.eventParticipantService.eventTicketInfo(
       userId,
       eventSlug,
+    );
+  }
+
+  @Get('v1/event-participant/get-social-networks')
+  @ApiBearerAuth()
+  @UseGuards(AuthUserGuard)
+  @ApiOperation({ summary: 'get social networks of event participant' })
+  @ApiResponse({
+    type: ParticipantSocialNetworks,
+  })
+  @ApiBadRequestResponse({ description: 'Bad request' })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getAllParticipantNetworks(
+    @Request() req: any,
+  ): Promise<ParticipantSocialNetworks> {
+    const userEmail = req.auth.user.email;
+    return await this.eventParticipantService.getAllParticipantNetworks(
+      userEmail,
     );
   }
 

--- a/src/modules/event-modules/event-participant/event/event-participant.service.ts
+++ b/src/modules/event-modules/event-participant/event/event-participant.service.ts
@@ -38,6 +38,8 @@ import {
   QuizCreateResponseDto,
   FindTicketByLinkResponseDto,
   UserIsParticipantInEventByLinkIdResponseDto,
+  ParticipantSocialNetworks,
+  ParticipantSocialNetworDto,
 } from './dto/event-participant-response.dto';
 import { ClickSignApiService } from 'src/services/click-sign.service';
 import * as mime from 'mime-types';
@@ -336,6 +338,47 @@ export class EventParticipantService {
         eventParticipantId: participantUpdated.id,
         participantStatus: participantUpdated.status,
       };
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async getAllParticipantNetworks(
+    userEmail: string,
+  ): Promise<ParticipantSocialNetworks> {
+    try {
+      const userExists = await this.prisma.user.findUnique({
+        where: {
+          email: userEmail.toLocaleLowerCase(),
+        },
+        include: {
+          userSocials: true,
+        },
+      });
+
+      if (!userExists) throw new NotFoundException('User not found');
+
+      if (userExists.userSocials.length <= 0) {
+        return;
+      }
+
+      const socialFormatted: ParticipantSocialNetworDto[] = [];
+
+      for (const social of userExists.userSocials) {
+        if (social.username) {
+          socialFormatted.push({
+            id: social.id,
+            network: social.network,
+            username: social.username,
+          });
+        }
+      }
+
+      const response: ParticipantSocialNetworks = {
+        data: socialFormatted,
+      };
+
+      return response;
     } catch (error) {
       throw error;
     }

--- a/src/modules/event-modules/event-participant/event/schema/event-participant-response.schema.ts
+++ b/src/modules/event-modules/event-participant/event/schema/event-participant-response.schema.ts
@@ -2,6 +2,7 @@ import {  CredentialType,
   EventLocation,
   EventQuizStatus,
   QuestionType,
+  UserNetworkType,
 } from '@prisma/client';
 import { z } from 'nestjs-zod/z';
 
@@ -254,4 +255,10 @@ export const UserIsParticipantInEventByLinkIdResponseSchema = z.object({
   isParticipant: z.boolean(),
   participantId: z.string().nullish(),
   haveFacial: z.boolean(),
+});
+
+export const ParticipantSocialNetworSchema = z.object({
+  id: z.number(),
+  network: z.nativeEnum(UserNetworkType).describe('User network type'),
+  username: z.string().describe('User network name'),
 });


### PR DESCRIPTION
Criado schema, service e controller para recuperar as redes sociais de um usuário especifico.

Rota no swagger

![image](https://github.com/user-attachments/assets/88c9ceea-ff19-4eea-a1b0-29478fd41bbb)


Schema de response

![image](https://github.com/user-attachments/assets/91b67302-f462-4641-99ec-a53a7f75a8f6)


Resultado do teste

![image](https://github.com/user-attachments/assets/6019a26d-e317-46c2-8509-0a733fafb050)
