### PR TITLE
1819/criar validacao facial

### DIFF
--- a/src/modules/user-modules/user-producer/user-producer.service.ts
+++ b/src/modules/user-modules/user-producer/user-producer.service.ts
@@ -1,5 +1,4 @@
-import {
-  BadRequestException,
+import {  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -243,6 +242,14 @@ export class UserProducerService {
 
       if (!userExists) {
         throw new NotFoundException('User not found');
+      }
+
+      const validFace = await this.storageService.isFaceValid(photo.buffer);
+
+      if (!validFace.isValid) {
+        throw new UnprocessableEntityException(
+          'A foto não possui um rosto, por favor tente novamente',
+        );
       }
 
       const currentDate = new Date();

--- a/src/services/face-validation.service.ts
+++ b/src/services/face-validation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';import { ConfigService } from '@nestjs/config';
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';import { ConfigService } from '@nestjs/config';
 import { PrismaService } from './prisma.service';
 import { StorageService, StorageServiceType } from './storage.service';
 
@@ -12,6 +12,14 @@ export class FaceValidationService {
 
   async validateWithFacial(userPhoto: Express.Multer.File) {
     try {
+      const validFace = await this.storageService.isFaceValid(userPhoto.buffer);
+
+      if (!validFace.isValid) {
+        throw new UnprocessableEntityException(
+          'A foto não possui um rosto, por favor tente novamente',
+        );
+      }
+
       const usersFacials = await this.prisma.userFacial.findMany({
         include: {
           user: true,


### PR DESCRIPTION
Adicionada validação nas rotas que ainda não retornavam 422 caso o usuário tentasse subir foto facial sem uma facial de fato.

**Validate Facial**
![image](https://github.com/user-attachments/assets/34893be5-d031-48cd-bde4-b6b892ff70b8)

**Upload user producer facial**
![image](https://github.com/user-attachments/assets/c23b7493-1a44-45ad-8898-9fdaa201d995)

imagem usada nos testes
![image](https://github.com/user-attachments/assets/8580a038-a8a2-4385-ab93-60766c28f158)


**testes**
_Validate Facial_
![image](https://github.com/user-attachments/assets/8177e5a8-81db-4726-8a1f-4f89afbebd45)

_Upload user producer facial_
![image](https://github.com/user-attachments/assets/5da39ace-5869-41b0-82dd-f534e6585a4e)


