### PR TITLE
1813/adicionar dono do event como staff

### DIFF
--- a/src/modules/event-modules/event-producer/event-staff/event-producer-staff.service.ts
+++ b/src/modules/event-modules/event-producer/event-staff/event-producer-staff.service.ts
@@ -1,4 +1,5 @@
-import {  BadRequestException,
+import {
+  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -225,6 +226,27 @@ export class EventProducerStaffService {
         eventSlug,
         userEmail.toLowerCase(),
       );
+
+      const staffExists = await this.prisma.eventStaff.findUnique({
+        where: {
+          id: staffId,
+          eventId: event.id,
+        },
+      });
+
+      const userProducer = await this.prisma.user.findUnique({
+        where: {
+          id: event.userId,
+        },
+      });
+
+      if (!staffExists) throw new NotFoundException('Staff not found');
+
+      if (staffExists.email === userProducer.email) {
+        throw new BadRequestException(
+          'Não é possivel deletar o produtor do evento da equipe',
+        );
+      }
 
       await this.prisma.eventStaff.delete({
         where: {

--- a/src/modules/event-modules/event-producer/event/event-producer.service.ts
+++ b/src/modules/event-modules/event-producer/event/event-producer.service.ts
@@ -1,4 +1,5 @@
-import {  BadRequestException,
+import {
+  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -361,6 +362,20 @@ export class EventProducerService {
           body,
         );
       }
+
+      const u = await this.prisma.user.findUnique({
+        where: {
+          email: user.email,
+        },
+      });
+
+      await this.prisma.eventStaff.create({
+        data: {
+          eventId: createdEvent.id,
+          email: user.email,
+          password: u.password,
+        },
+      });
 
       return {
         id: createdEvent.id,

--- a/src/modules/event-modules/event-producer/event/event-producer.service.ts
+++ b/src/modules/event-modules/event-producer/event/event-producer.service.ts
@@ -363,17 +363,18 @@ export class EventProducerService {
         );
       }
 
-      const u = await this.prisma.user.findUnique({
-        where: {
-          email: user.email,
-        },
-      });
+      const userInformationToCreateUserAsStaff =
+        await this.prisma.user.findUnique({
+          where: {
+            email: user.email,
+          },
+        });
 
       await this.prisma.eventStaff.create({
         data: {
           eventId: createdEvent.id,
           email: user.email,
-          password: u.password,
+          password: userInformationToCreateUserAsStaff.password,
         },
       });
 


### PR DESCRIPTION
Adicionado lógica para que quando criar um evento o produtor seja adicionado automaticamente aos staffs.
Criado validação na hora de delatar os staffs, para que seja impossivel tirar o produtor como staff do evento.

porém essa lógica precisará ser adequada ao rework da staff, não complemente, apenas a hora de criar o produtor como staff