### PR TITLE
refactor-get-all-links-with-one-ticket-return-by-ticketpriceid

### DIFF
--- a/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.controller.ts
+++ b/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.controller.ts
@@ -264,7 +264,7 @@ export class EventTicketProducerController {
     return this.eventTicketProducerService.cuponsDashboard(email, eventSlug);
   }
 
-  @Get('v1/event-producer/:eventSlug/tickets/:ticketId/links')
+  @Get('v1/event-producer/:eventSlug/tickets/:ticketId/:ticketPriceId/links')
   @ApiBearerAuth()
   @UseGuards(AuthUserGuard)
   @ApiOperation({ summary: 'Get all links with one ticket' })
@@ -285,6 +285,11 @@ export class EventTicketProducerController {
     required: true,
     type: String,
   })
+  @ApiParam({
+    name: 'ticketPriceId',
+    required: true,
+    type: String,
+  })
   @ApiQuery({
     name: 'page',
     required: true,
@@ -299,6 +304,7 @@ export class EventTicketProducerController {
     @Request() req: any,
     @Param('eventSlug') eventSlug: string,
     @Param('ticketId') ticketId: string,
+    @Param('ticketPriceId') ticketPriceId: string,
     @Query('page') page: number = 1,
     @Query('perPage') perPage: number = 10,
   ): Promise<EventTicketLinkResponse> {
@@ -307,6 +313,7 @@ export class EventTicketProducerController {
       userEmail,
       eventSlug,
       ticketId,
+      ticketPriceId,
       Number(page),
       Number(perPage),
     );

--- a/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.service.ts
+++ b/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.service.ts
@@ -674,9 +674,11 @@ export class EventTicketProducerService {
     userEmail: string,
     eventSlug: string,
     ticketId: string,
+    ticketPriceId: string,
     page: number,
     perPage: number,
   ): Promise<EventTicketLinkResponse> {
+
     try {
       const user = await this.prisma.user.findUnique({
         where: {
@@ -698,7 +700,9 @@ export class EventTicketProducerService {
       const where: Prisma.EventTicketLinkWhereInput = {
         eventTicketId: ticketId,
         userId: null,
+        eventTicketPriceId: ticketPriceId
       };
+
 
       const links = await this.prisma.eventTicketLink.findMany({
         where,
@@ -715,6 +719,7 @@ export class EventTicketProducerService {
         take: Number(perPage),
         skip: (page - 1) * perPage,
       });
+
 
       const totalItems = await this.prisma.eventTicketLink.count({
         where,


### PR DESCRIPTION
<h3>refactor-get-all-links-with-one-ticket-return-by-ticketpriceid</h3>
<hr>
Como os links privados serão gerados individualmente, o usuário precisará ver na tela de tickets, os links já gerados por lote. Por isso, a rota foi alterada para receber o id do lote, e retornar somente os links gerados desse lote.