### PR TITLE
refactor:alter event ticket all route to return only private tickets

### DIFF
--- a/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.controller.ts
+++ b/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.controller.ts
@@ -177,12 +177,18 @@ export class EventTicketProducerController {
     required: false,
     type: String,
   })
+  @ApiQuery({
+    name: 'isPrivate',
+    required: false,
+    type: Boolean,
+  })
   async findAllEventTicket(
     @Param('eventSlug') eventSlug: string,
     @Request() req: any,
     @Query('page') page: number = 1,
     @Query('perPage') perPage: number = 10,
     @Query('title') title?: string,
+    @Query('isPrivate') isPrivate?: boolean,
   ): Promise<EventTicketsResponse> {
     const email = req.auth.user.email;
     return this.eventTicketProducerService.findAllEventTicket(
@@ -191,6 +197,7 @@ export class EventTicketProducerController {
       page,
       perPage,
       title,
+      isPrivate
     );
   }
 
@@ -351,6 +358,7 @@ export class EventTicketProducerController {
         },
       },
     },
+    required: true
   })
   async sendInviteLinkByEmail(
     @Param('eventSlug') eventSlug: string,

--- a/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.service.ts
+++ b/src/modules/event-modules/event-producer/event-ticket/event-ticket-producer.service.ts
@@ -298,7 +298,9 @@ export class EventTicketProducerService {
     page: number,
     perPage: number,
     title?: string,
+    isPrivate?: boolean
   ): Promise<EventTicketsResponse> {
+
     try {
       const event = await this.userProducerValidationService.eventExists(
         eventSlug,
@@ -309,6 +311,10 @@ export class EventTicketProducerService {
         eventId: event.id,
         isBonus: false,
       };
+
+      if (isPrivate) {
+        where.isPrivate = true
+      }
 
       if (title) {
         where.title = {
@@ -944,6 +950,10 @@ private async processCSV(file: Express.Multer.File): Promise<any> {
     let index = 0;
 
     line.on('line', (data) => {
+      if(index === 0){
+        index += 1;
+        return
+      }
       index += 1;
       let csv = data.split(';');
 
@@ -994,6 +1004,7 @@ private async processCSV(file: Express.Multer.File): Promise<any> {
     let uncompleted = [];
 
     data.forEach((row, index) => {
+      if (index === 0) return //ignorar a primeira linha do arquivo
       let realLine = index + 1
 
       let user = {

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -253,7 +253,7 @@ export class EmailService {
       from: 'Nex Event ' + from,
       to: to,
       subject: subject,
-      html: html,
+      html: html
     };
 
     const mailgun = new Mailgun(formData);

--- a/src/services/user-producer-validation.service.ts
+++ b/src/services/user-producer-validation.service.ts
@@ -181,7 +181,7 @@ export class UserProducerValidationService {
     }
   }
 
-  async eventExists(slug: string, userEmail: String) {
+    async eventExists(slug: string, userEmail: String, paramPica?: string) {
     const event = await this.prisma.event.findUnique({
       where: {
         slug: slug,
@@ -191,16 +191,24 @@ export class UserProducerValidationService {
         eventTicket: true,
       },
     });
-  
+
+    if (paramPica) {
+      await this.validateUserProducerByEmail(
+        userEmail.toLowerCase(),
+        null,
+        event.id,
+      );
+    } else {
+      await this.validateUserProducerByEmail(
+        userEmail.toLowerCase(),
+        null,
+        event.id,
+      );
+    }
+
     if (!event) {
       throw new NotFoundException('Event not found');
     }
-
-    await this.validateUserProducerByEmail(
-      userEmail.toLowerCase(),
-      null,
-      event.id,
-    );
 
     return event;
   }


### PR DESCRIPTION
A rota de retorno de todos os tickets de um evento foi alterada para filtrar por query param, somente ingressos privados:
<br>

![image](https://github.com/user-attachments/assets/ec2f1e8d-0d9d-42e4-bab1-9fa9081d2a61)

![image](https://github.com/user-attachments/assets/e40c0f1d-bc34-43fc-9837-c39d9dfed953)
