### PR TITLE
refactor: update status staff and email create staff

### DIFF
--- a/src/modules/event-modules/event-producer/event-staff/event-producer-staff.controller.ts
+++ b/src/modules/event-modules/event-producer/event-staff/event-producer-staff.controller.ts
@@ -227,18 +227,19 @@ export class EventProducerStaffController {
   @ApiQuery({
     name: 'acceptedInvite',
     required: false,
-    type: Boolean,
+    type: String,
   })
   async updateEventStaff(
     @Request() req: any,
     @Param('eventSlug') eventSlug: string,
-    @Query('acceptedInvite') acceptedInvite: boolean,
+    @Query('acceptedInvite') acceptedInvite: string,
   ) {
     const userId = req.auth.user.id;
+    const accepted = acceptedInvite === 'true' ? true : false;
     return await this.eventProducerStaffService.updateEventStaff(
       userId,
       eventSlug,
-      acceptedInvite,
+      accepted,
     );
   }
 
@@ -264,7 +265,7 @@ export class EventProducerStaffController {
     const email = req.auth.user.email;
     return await this.eventProducerStaffService.resendInviteEmail(
       email,
-      staffId
+      staffId,
     );
   }
 

--- a/src/modules/event-modules/event-producer/event-staff/event-producer-staff.service.ts
+++ b/src/modules/event-modules/event-producer/event-staff/event-producer-staff.service.ts
@@ -42,6 +42,8 @@ export class EventProducerStaffService {
 
       const { email } = body;
 
+      if (!email) throw new NotFoundException('Email sent empty');
+
       const staffAlreadyExists = await this.prisma.eventStaff.findFirst({
         where: {
           eventId: event.id,
@@ -58,7 +60,7 @@ export class EventProducerStaffService {
         where: { email: email.toLowerCase() },
       });
 
-      if (userExists.email.toLowerCase() === email.toLowerCase()) {
+      if (userEmail.toLowerCase() === email.toLowerCase()) {
         throw new UnprocessableEntityException(
           'This user is the producer of this event',
         );


### PR DESCRIPTION
Update: Validar o boolean vindo na request para atualização do status do convite staff, porque estava convertendo em string, e mesmo se o staff recusasse, estava confirmando .

Update: Trocar a variável de comparação para verificação da existência do Staff antes de sua criação