### PR TITLE
1765/create crud sponser user

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
-import { Module } from '@nestjs/common';import { PrismaService } from './services/prisma.service';
+import { Module } from '@nestjs/common';
+import { PrismaService } from './services/prisma.service';
 import { APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { ZodSerializerInterceptor, ZodValidationPipe } from 'nestjs-zod';
 import { AuthModule } from './modules/auth-modules/auth/auth.module';
@@ -16,6 +17,7 @@ import { EventParticipantCronModule } from './modules/cron-modules/event-partici
 import { EventQuizModule } from './modules/event-modules/event-producer/event-quiz/event.quiz.module';
 import { ConfigModule } from '@nestjs/config';
 import variables from './variables';
+import { SponsorUserModule } from './modules/user-modules/sponser-user/sponsor-user.module';
 
 @Module({
   imports: [
@@ -26,6 +28,7 @@ import variables from './variables';
     ScheduleModule.forRoot(),
     AuthModule,
     UserProducerModule,
+    SponsorUserModule,
     EventProducerModule,
     EventTicketProducerModule,
     EventNetworkProducerModule,

--- a/src/modules/user-modules/sponser-user/dto/create-sponser-user.dto.ts
+++ b/src/modules/user-modules/sponser-user/dto/create-sponser-user.dto.ts
@@ -1,0 +1,6 @@
+import { createZodDto } from 'nestjs-zod';
+import { CreateSponsorUserSchema } from '../schemas/create-sponsor-user.schema';
+
+export class CreateSponsorUserDto extends createZodDto(
+  CreateSponsorUserSchema,
+) {}

--- a/src/modules/user-modules/sponser-user/dto/response-sponser-user.dto.ts
+++ b/src/modules/user-modules/sponser-user/dto/response-sponser-user.dto.ts
@@ -1,0 +1,6 @@
+import { createZodDto } from 'nestjs-zod';
+import { ResponseSponsorUserSchema } from '../schemas/response-sponsor-user.schema';
+
+export class ResponseSponsorUserDto extends createZodDto(
+  ResponseSponsorUserSchema,
+) {}

--- a/src/modules/user-modules/sponser-user/dto/update-sponser-user.dto.ts
+++ b/src/modules/user-modules/sponser-user/dto/update-sponser-user.dto.ts
@@ -1,0 +1,6 @@
+import { createZodDto } from 'nestjs-zod';
+import { UpdateSponsorUserSchema } from '../schemas/update-sponsor-user.schema';
+
+export class UpdateSponsorUserDto extends createZodDto(
+  UpdateSponsorUserSchema,
+) {}

--- a/src/modules/user-modules/sponser-user/schemas/create-sponsor-user.schema.ts
+++ b/src/modules/user-modules/sponser-user/schemas/create-sponsor-user.schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'nestjs-zod/z';
+
+export const CreateSponsorUserSchema = z.object({
+  publicKey: z.string(),
+  secretKey: z.string(),
+});

--- a/src/modules/user-modules/sponser-user/schemas/response-sponsor-user.schema.ts
+++ b/src/modules/user-modules/sponser-user/schemas/response-sponsor-user.schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'nestjs-zod/z';
+
+export const ResponseSponsorUserSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  secretKey: z.string(),
+  publicKey: z.string(),
+});

--- a/src/modules/user-modules/sponser-user/schemas/update-sponsor-user.schema.ts
+++ b/src/modules/user-modules/sponser-user/schemas/update-sponsor-user.schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'nestjs-zod/z';
+
+export const UpdateSponsorUserSchema = z.object({
+  publicKey: z.string().nullish(),
+  secretKey: z.string().nullish(),
+});

--- a/src/modules/user-modules/sponser-user/sponsor-user.controller.ts
+++ b/src/modules/user-modules/sponser-user/sponsor-user.controller.ts
@@ -1,0 +1,88 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiCreatedResponse,
+  ApiInternalServerErrorResponse,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { SponsorUserService } from './sponsor-user.service';
+import { CreateSponsorUserDto } from './dto/create-sponser-user.dto';
+import { ResponseSponsorUserDto } from './dto/response-sponser-user.dto';
+import { AuthUserGuard } from 'src/modules/auth-modules/auth/auth-user.guards';
+import { UpdateSponsorUserDto } from './dto/update-sponser-user.dto';
+
+@ApiTags('Sponsor User')
+@Controller('sponsor-user')
+export class SponsorUserController {
+  constructor(private readonly sponsorUserService: SponsorUserService) {}
+
+  @Post('v1/sponsor-user')
+  @ApiBearerAuth()
+  @UseGuards(AuthUserGuard)
+  @ApiOperation({ summary: 'Create Sponsor User' })
+  @ApiCreatedResponse({
+    type: ResponseSponsorUserDto,
+  })
+  @ApiBadRequestResponse({ description: 'Bad request' })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  @ApiBody({
+    type: CreateSponsorUserDto,
+  })
+  async createSponsorUser(
+    @Request() req: any,
+    @Body() body: CreateSponsorUserDto,
+  ): Promise<ResponseSponsorUserDto> {
+    const userId = req.auth.user.id;
+    return this.sponsorUserService.createSponsor(userId, body);
+  }
+
+  @Get('v1/sponsor-user')
+  @ApiBearerAuth()
+  @UseGuards(AuthUserGuard)
+  @ApiOperation({ summary: 'Get Sponsor User' })
+  @ApiResponse({
+    status: 200,
+    type: ResponseSponsorUserDto,
+  })
+  @ApiBadRequestResponse({ description: 'Bad request' })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  async getSponserUser(
+    @Request() req: any,
+  ): Promise<ResponseSponsorUserDto | null> {
+    const userId = req.auth.user.id;
+    return this.sponsorUserService.findSponsorUser(userId);
+  }
+
+  @Patch('v1/sponsor-user')
+  @ApiBearerAuth()
+  @UseGuards(AuthUserGuard)
+  @ApiOperation({ summary: 'Update Sponsor User' })
+  @ApiResponse({
+    status: 200,
+    type: ResponseSponsorUserDto,
+  })
+  @ApiBadRequestResponse({ description: 'Bad request' })
+  @ApiInternalServerErrorResponse({ description: 'Internal server error' })
+  @ApiBody({
+    type: UpdateSponsorUserDto,
+  })
+  async update(
+    @Request() req: any,
+    @Body() body: UpdateSponsorUserDto,
+  ): Promise<ResponseSponsorUserDto> {
+    const userId = req.auth.user.id;
+    return await this.sponsorUserService.update(userId, body);
+  }
+}

--- a/src/modules/user-modules/sponser-user/sponsor-user.module.ts
+++ b/src/modules/user-modules/sponser-user/sponsor-user.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SponsorUserController } from './sponsor-user.controller';
+import { SponsorUserService } from './sponsor-user.service';
+import { PrismaService } from 'src/services/prisma.service';
+
+@Module({
+  controllers: [SponsorUserController],
+  providers: [SponsorUserService, PrismaService],
+})
+export class SponsorUserModule {}

--- a/src/modules/user-modules/sponser-user/sponsor-user.service.ts
+++ b/src/modules/user-modules/sponser-user/sponsor-user.service.ts
@@ -1,0 +1,125 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from 'src/services/prisma.service';
+import { CreateSponsorUserDto } from './dto/create-sponser-user.dto';
+import { ResponseSponsorUserDto } from './dto/response-sponser-user.dto';
+import { ResponseSponsorUserSchema } from './schemas/response-sponsor-user.schema';
+import { UpdateSponsorUserDto } from './dto/update-sponser-user.dto';
+
+@Injectable()
+export class SponsorUserService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createSponsor(
+    userId: string,
+    body: CreateSponsorUserDto,
+  ): Promise<ResponseSponsorUserDto> {
+    try {
+      const sponsorAlreadyExists = await this.findSponsorUser(userId);
+
+      if (sponsorAlreadyExists)
+        throw new ConflictException('Sponsor user already exists');
+
+      const { publicKey, secretKey } = body;
+
+      const sponsorUser = await this.prisma.sponsorUser.create({
+        data: {
+          userId,
+          publicKey,
+          secretKey,
+        },
+      });
+
+      const response: ResponseSponsorUserDto = {
+        id: sponsorUser.id,
+        userId: sponsorUser.userId,
+        publicKey: sponsorUser.publicKey,
+        secretKey: sponsorUser.secretKey,
+      };
+
+      await ResponseSponsorUserSchema.parseAsync(response);
+
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async findSponsorUser(
+    userId: string,
+  ): Promise<ResponseSponsorUserDto | null> {
+    try {
+      const userExists = await this.prisma.user.findUnique({
+        where: {
+          id: userId,
+        },
+      });
+
+      if (!userExists) throw new NotFoundException('User not found');
+
+      const sponsorAlreadyExists = await this.prisma.sponsorUser.findFirst({
+        where: {
+          userId: userId,
+        },
+      });
+
+      if (sponsorAlreadyExists) {
+        const response: ResponseSponsorUserDto = {
+          id: sponsorAlreadyExists.id,
+          userId: sponsorAlreadyExists.userId,
+          publicKey: sponsorAlreadyExists.publicKey,
+          secretKey: sponsorAlreadyExists.secretKey,
+        };
+
+        await ResponseSponsorUserSchema.parseAsync(response);
+
+        return response;
+      }
+
+      return null;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async update(
+    userId: string,
+    body: UpdateSponsorUserDto,
+  ): Promise<ResponseSponsorUserDto> {
+    try {
+      const sponsorAlreadyExists = await this.findSponsorUser(userId);
+
+      if (!sponsorAlreadyExists)
+        throw new NotFoundException('Sponser user not found');
+
+      const { publicKey, secretKey } = body;
+
+      const sponsorUser = await this.prisma.sponsorUser.update({
+        where: {
+          userId: userId,
+          id: sponsorAlreadyExists.id,
+        },
+        data: {
+          publicKey: publicKey ? publicKey : sponsorAlreadyExists.publicKey,
+          secretKey: secretKey ? secretKey : sponsorAlreadyExists.secretKey,
+        },
+      });
+
+      const response: ResponseSponsorUserDto = {
+        id: sponsorUser.id,
+        userId: sponsorUser.userId,
+        publicKey: sponsorUser.publicKey,
+        secretKey: sponsorUser.secretKey,
+      };
+
+      await ResponseSponsorUserSchema.parseAsync(response);
+
+      return response;
+    } catch (error) {
+      throw error;
+    }
+  }
+}

--- a/src/modules/user-modules/sponser-user/sponsor-user.service.ts
+++ b/src/modules/user-modules/sponser-user/sponsor-user.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -24,6 +25,8 @@ export class SponsorUserService {
         throw new ConflictException('Sponsor user already exists');
 
       const { publicKey, secretKey } = body;
+
+      this.validateStripeKeys(publicKey, secretKey);
 
       const sponsorUser = await this.prisma.sponsorUser.create({
         data: {
@@ -97,6 +100,8 @@ export class SponsorUserService {
 
       const { publicKey, secretKey } = body;
 
+      this.validateStripeKeys(publicKey, secretKey);
+
       const sponsorUser = await this.prisma.sponsorUser.update({
         where: {
           userId: userId,
@@ -120,6 +125,19 @@ export class SponsorUserService {
       return response;
     } catch (error) {
       throw error;
+    }
+  }
+
+  private validateStripeKeys(publicKey?: string, secretKey?: string): void {
+    const publicKeyPattern = /^pk_(test|live)_[a-zA-Z0-9]{24,}$/;
+    const secretKeyPattern = /^sk_(test|live)_[a-zA-Z0-9]{24,}$/;
+
+    if (!publicKeyPattern.test(publicKey) && publicKey) {
+      throw new BadRequestException('Invalid Stripe public key');
+    }
+
+    if (!secretKeyPattern.test(secretKey) && secretKey) {
+      throw new BadRequestException('Invalid Stripe secret key');
     }
   }
 }


### PR DESCRIPTION
Created new module for save stripe keys with Sponsor User.

create route
![image](https://github.com/user-attachments/assets/79e267dc-58fe-4113-aec2-e57b301599a2)

erro empty values
![image](https://github.com/user-attachments/assets/c4f7b759-2523-4793-92e9-70b516df02f7)

erro sponsor already exist
![image](https://github.com/user-attachments/assets/b3e4ee43-344b-4c98-a541-93a6a4628360)

success created
![image](https://github.com/user-attachments/assets/c17eddeb-73b5-4644-be8d-34e6ecb62a04)

get route
![image](https://github.com/user-attachments/assets/68a84c25-8c7c-4bb5-b4f9-14dd31912978)

the success response is the same on all routes

update route
![image](https://github.com/user-attachments/assets/c528d3c0-98c4-4a5a-8d79-d2032e4cc98c)

all fields can be null